### PR TITLE
Added possibility to overrule a specific service with your own mock/implementation

### DIFF
--- a/src/PSS/SymfonyMockerContainer/DependencyInjection/MockerContainer.php
+++ b/src/PSS/SymfonyMockerContainer/DependencyInjection/MockerContainer.php
@@ -34,6 +34,15 @@ class MockerContainer extends Container
     }
 
     /**
+     * @param string $id
+     * @param object $mock
+     */
+    public function setMock($id, $mock)
+    {
+        self::$mockedServices[$id] = $mock;
+    }
+
+    /**
      * @return null
      */
     public function unmock($id)

--- a/src/PSS/SymfonyMockerContainer/Tests/DependencyInjection/MockerContainerTest.php
+++ b/src/PSS/SymfonyMockerContainer/Tests/DependencyInjection/MockerContainerTest.php
@@ -61,6 +61,22 @@ class MockerContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($mock, $this->container->get('test.service_1'));
     }
 
+    public function testThatServiceCanBeSet()
+    {
+        $mock = new \stdClass();
+        $this->container->setMock('test.service_1', $mock);
+
+        $this->assertSame($mock, $this->container->get('test.service_1'));
+    }
+
+    public function testThatUnsetServiceFallsbackToOriginalService()
+    {
+        $this->container->setMock('test.service_1', new \stdClass());
+        $this->container->unmock('test.service_1');
+
+        $this->assertSame($this->services['test.service_1'], $this->container->get('test.service_1'));
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Cannot mock unexisting service: "test.new_service"


### PR DESCRIPTION
Hi, I added the possibility to overrule some service with your own implementation (e.g. to implement some interface with another test stub). This is handy when multiple functions are called on your service and you don't want to  mock everything.