### PR TITLE
Symfony 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: php
 matrix:
   include:
     - php: 8.0
+      env: SYMFONY_VERSION=^4.3
+    - php: 8.0
+      env: SYMFONY_VERSION=^5.0
+    - php: 8.0
+      env: SYMFONY_VERSION=^6.0
+
+before_install:
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:$SYMFONY_VERSION; fi
 
 install:
   - if [[ $deps = low ]]; then composer update --prefer-lowest --prefer-stable; else composer install; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 7.2
-      env: deps=low
-    - php: 7.3
-    - php: 7.4
     - php: 8.0
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php":                          "^7.2 || ^8.0",
+        "php":                          "^8.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "mockery/mockery":              "^1.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php":                          "^8.0",
-        "symfony/dependency-injection": "^4.3 || ^5.0",
+        "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
         "mockery/mockery":              "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
It would be great to have this library with Symfony 6 (we're still using it in Sylius :dancer:). I've also dropped PHP7 as not supported anymore and not possible to use with Symfony 6 (I can bring it back if you need it).

@jakzal it would be wonderful to have it merged and released (even though I know the library is not maintained heavily) 🖖 

I can also provide a Github Actions configuration PR, as I don't know if Travis still works 🔥 