### PR TITLE
Bring back Symfony 4 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
           php: ["8.0", "8.1"]
-          symfony: ["^5.4", "^6.0"]
+          symfony: ["^4.4", "^5.4", "^6.0"]
 
     steps:
 

--- a/src/DependencyInjection/MockerContainer.php
+++ b/src/DependencyInjection/MockerContainer.php
@@ -47,7 +47,7 @@ class MockerContainer extends Container
      *
      * @return object
      */
-    public function get(string $id, int $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE): ?object
+    public function get($id, $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE): ?object
     {
         if (array_key_exists($id, self::$mockedServices)) {
             return self::$mockedServices[$id];
@@ -61,7 +61,7 @@ class MockerContainer extends Container
      *
      * @return boolean
      */
-    public function has(string $id): bool
+    public function has($id): bool
     {
         if (array_key_exists($id, self::$mockedServices)) {
             return true;


### PR DESCRIPTION
It's strange, that it works, but it does :dancer: 

Proof on Sylius with Symfony 4 & 5: https://github.com/Zales0123/Sylius/actions/runs/3266294029
Proof on Sylius with Symfony 5 & 6: https://github.com/Zales0123/Sylius/actions/runs/3266316900

I believe after this merge we should release a final fix and then a 2.0 version with this workaround dropped 🖖 